### PR TITLE
Refactor zip task to build-dist. Use web-ext build for firefox. Fix e…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
     "parser": "espree",
     "parserOptions": {
-        "ecmaVersion": 7,
+        "ecmaVersion": 8,
         "sourceType": "module",
         "ecmaFeatures": {}
     },


### PR DESCRIPTION
This uses web-ext build for firefox. Had to split the deploy step, because web-ext sign cannot use a zip. Also the zip is now placed to a dist dir instead of the build dir. Made the deploy use async and updated ecma version in eslintrc, so it doesn't fail on parsing async functions.