### PR TITLE
Refactor callstatus polling. Make callstatus modal fullscreen. Block …

### DIFF
--- a/src/js/lib/app.js
+++ b/src/js/lib/app.js
@@ -19,7 +19,6 @@ class App extends Skeleton {
 
         // Some caching mechanism.
         window.cache = {}
-
         this.store = new Store(this)
 
         // Store settings to localstorage.
@@ -29,15 +28,6 @@ class App extends Skeleton {
                     this.store.set(key, this.settings[key])
                 }
             }
-        }
-
-        // Checkout the contents of localstorage.
-        if (this.verbose) {
-            let localStorageDump = `${this}localstorage contains...\n`
-            for (let i = 0; i < localStorage.length; i++) {
-                localStorageDump += `${localStorage.key(i)}=${localStorage.getItem(localStorage.key(i))}\n`
-            }
-            this.logger.debug(localStorageDump)
         }
 
         // Keep track of some notifications.

--- a/src/js/lib/logger.js
+++ b/src/js/lib/logger.js
@@ -14,6 +14,7 @@ class Logger {
             verbose: 3,
             warn: 1,
         }
+        this._notification = null
     }
 
 
@@ -47,7 +48,7 @@ class Logger {
     }
 
 
-    notification(message, title = 'Click-to-dial') {
+    notification(message, title = 'Click-to-dial', stack = false) {
         const options = {
             message: message,
             title: title,
@@ -55,16 +56,20 @@ class Logger {
         }
         if (this.app.env.extension) {
             options.iconUrl = this.app.browser.runtime.getURL('img/logo.png')
-            this.app.browser.notifications.create(message, options)
+            if (!stack) chrome.notifications.clear('c2d')
+            this.app.browser.notifications.create('c2d', options)
         } else {
             options.iconUrl = 'img/clicktodial.png'
             if (Notification.permission === 'granted') {
-                new Notification(message, options) // eslint-disable-line no-new
+                if (!stack && this._notification) this._notification.close()
+                this._notification = new Notification(message, options) // eslint-disable-line no-new
             } else if (Notification.permission !== 'denied') {
-                // Create a notification after the user accepted the permission.
+                // Create a notification after the user
+                // accepted the permission.
                 Notification.requestPermission(function(permission) {
                     if (permission === 'granted') {
-                        new Notification(message, options) // eslint-disable-line no-new
+                        if (!stack && this._notification) this._notification.close()
+                        this._notification = new Notification(message, options) // eslint-disable-line no-new
                     }
                 })
             }

--- a/src/js/lib/sip.js
+++ b/src/js/lib/sip.js
@@ -281,7 +281,6 @@ class Sip {
                 this.app.logger.debug(`${this}not updating from sip server; no sipstack available`)
                 return
             }
-            this.app.logger.debug(`${this}updating sip subscription for ${accountIds.length} account id's`)
 
             // Unsubscribe lost contacts that are in cache, but not in
             // the accountIds refresh array.
@@ -291,6 +290,7 @@ class Sip {
             }
 
             const accountIdsWithoutState = accountIds.filter((accountId) => !(accountId in this.states))
+            this.app.logger.debug(`${this}updating sip subscription for ${accountIdsWithoutState.length} account id's`)
             // Don't do this in parallel, to keep the load on the websocket
             // server low. Also subscribePresence has a fixed timeout before
             // it resolves the connected state, to further slow down the

--- a/src/js/lib/timer.js
+++ b/src/js/lib/timer.js
@@ -29,7 +29,6 @@ class Timer {
             return registeredTimers[timerId]
         }
 
-        this.app.logger.warn(`${this}no such timer ${timerId}`)
         return null
     }
 

--- a/src/js/modules/observer/index.js
+++ b/src/js/modules/observer/index.js
@@ -70,16 +70,21 @@ class ObserverModule {
         })
 
         /**
-        * Handle a click on a click-to-dial icon next to a phonenumber on a
-        * page. Use the number in the attribute `data-number`.
+        * Handle a click on a click-to-dial icon next to a phonenumber within
+        * a tab. Use the number in the attribute `data-number`.
         */
         $('body').on('click', `.${phoneIconClassName}`, (e) => {
-            if (!$(e.currentTarget).attr('disabled') &&
-                $(e.currentTarget).attr('data-number') &&
-                $(e.currentTarget).parents(`.${phoneElementClassName}`).length
-            ) {
-                // Disable all c2d icons until the callstatus
-                // popup is closed again.
+            // Don't process the click when the icon has
+            // a disabled property set.
+            if ($(e.currentTarget).attr('disabled')) {
+                e.preventDefault()
+                return
+            }
+
+            if ($(e.currentTarget).attr('data-number') &&
+                $(e.currentTarget).parents(`.${phoneElementClassName}`).length) {
+                // Disable all c2d icons until the tab is notified
+                // by the callstatus that it wants to close again.
                 $(`.${phoneIconClassName}`).each((i, el) => {
                     $(el).attr('disabled', true)
                 })
@@ -92,6 +97,7 @@ class ObserverModule {
 
                 const b_number = $(e.currentTarget).attr('data-number')
                 this.app.emit('dialer:dial', {
+                    analytics: 'Webpage',
                     b_number: b_number,
                 })
             }
@@ -110,7 +116,10 @@ class ObserverModule {
 
             // Dial the b_number.
             const bNumber = $(e.currentTarget).attr('href').substring(4)
-            this.app.emit('dialer:dial', {b_number: bNumber})
+            this.app.emit('dialer:dial', {
+                analytics: 'Webpage',
+                b_number: bNumber,
+            })
         })
     }
 

--- a/src/js/modules/queues/actions.js
+++ b/src/js/modules/queues/actions.js
@@ -52,8 +52,8 @@ class QueuesActions extends Actions {
 
 
     /**
-     * Popup script related events.
-     */
+    * Popup script related events.
+    */
     _popup() {
         if (!('queue' in this.app.cache)) {
             this.app.cache.queue = {
@@ -66,7 +66,7 @@ class QueuesActions extends Actions {
             $('.queues .empty-list').removeClass('hide')
         })
 
-        // Fill the queue list.
+        // Fill the queue list with data from the background.
         this.app.on('queues:fill', (data) => {
             let queues = data.queues
             let selectedQueue = data.selectedQueue
@@ -104,8 +104,7 @@ class QueuesActions extends Actions {
         })
 
         this.app.on('queues:reset', (data) => {
-            let list = $('.queues .list')
-            list.empty()
+            $('.queues .list').empty()
             $('.queues .empty-list').addClass('hide')
         })
 
@@ -122,8 +121,8 @@ class QueuesActions extends Actions {
         })
 
         /**
-         * Select a queue.
-         */
+        * Select a queue.
+        */
         $('.queues .list').on('click', '.queue', (e) => {
             let target = e.currentTarget
             let queueId = null

--- a/src/js/modules/queues/index.js
+++ b/src/js/modules/queues/index.js
@@ -1,17 +1,17 @@
 /**
- * @module Queues
- */
+* @module Queues
+*/
 const QueuesActions = require('./actions')
 
 
 /**
- * The Queues module.
- */
+* The Queues module.
+*/
 class QueuesModule {
 
     /**
-     * @param {ClickToDialApp} app - The application object.
-     */
+    * @param {ClickToDialApp} app - The application object.
+    */
     constructor(app) {
         this.app = app
         this.app.modules.queues = this
@@ -141,6 +141,7 @@ class QueuesModule {
                     })
 
                     this.app.emit('queues:reset')
+                    // Pass the queues to the popup.
                     this.app.emit('queues:fill', {
                         queues: queues,
                         selectedQueue: this.app.store.get('widgets').queues.selected,
@@ -183,7 +184,6 @@ class QueuesModule {
 
     _restore() {
         this.app.logger.info(`${this}reloading widget queues`)
-
         // Check if unauthorized.
         let widgetState = this.app.store.get('widgets')
         if (widgetState.queues.unauthorized) {

--- a/src/js/modules/ui/actions.js
+++ b/src/js/modules/ui/actions.js
@@ -66,11 +66,6 @@ class UiActions extends Actions {
         this.app.on('ui:mainpanel.close', (data) => {
             this.app.logger.info(`${this}mainpanel.close`)
         })
-
-        this.app.on('panel.dial', (data) => {
-            this.app.modules.dialer.dial(data.b_number, null, true)
-            this.app.analytics.trackClickToDial('Colleagues')
-        })
     }
 
     /**

--- a/src/scss/base/mixins.scss
+++ b/src/scss/base/mixins.scss
@@ -3,9 +3,7 @@
 }
 
 @mixin vg-modal-widget {
-    position: fixed;
     border-radius: $vg-border-radius;
-    width: 100%;
     margin-left: 0;
     margin-top: 0;
 

--- a/src/scss/components/contacts.scss
+++ b/src/scss/components/contacts.scss
@@ -27,8 +27,9 @@
             padding-top: 7px;
             height: $vg-widget-header-size;
             line-height: 30px;
-            opacity: 0.3;
+            opacity: .3;
             vertical-align: middle;
+            font-size: 1rem;
         }
 
         // The input element to search with.
@@ -40,6 +41,7 @@
             border: 1px solid $vg-grey-lighter;
             height: $vg-widget-header-size - $vg-spacing-2;
             width: 195px;
+            font-size: .9rem;
         }
     }
 
@@ -70,7 +72,6 @@
         &.last {
             margin-bottom: 0;
         }
-
 
         &.hide {
             display: none;
@@ -109,22 +110,40 @@
                 max-width: 200px;
                 display: inline;
                 font-weight: 500;
-                cursor: pointer;
                 text-overflow: ellipsis;
                 white-space: nowrap;
             }
 
             .extension {
-                display: inline;
+                display: inline-block;
+                color: #9b9c9e;
+                font-weight: normal;
             }
         }
 
-        .extension {
-            display: inline-block;
-            color: #9b9c9e;
-            font-weight: normal;
-            cursor: pointer;
+        &:hover {
+            .info .name,
+            .info .extension,
+            .status-icon {
+                &:hover {
+                    cursor: pointer;
+                }
+            }
         }
+
+        &[disabled] {
+            opacity: .6;
+
+            .info .name,
+            .info .extension,
+            .status-icon {
+                &:hover {
+                    cursor: default;
+                }
+            }
+        }
+
+
 
         // Default row list can be done with css.
         &:nth-child(odd) {

--- a/src/scss/webext_callstatus.scss
+++ b/src/scss/webext_callstatus.scss
@@ -4,18 +4,32 @@
 @import "base/fonts";
 @import "components/widget";
 
+html,
+body {
+    width: 100%;
+    height: 100%;
+}
+
+body {
+    background: rgba(0, 0, 0, 0.25);
+}
 
 .widget.callstatus {
     @include vg-modal-widget;
-
-    width: 100%;
+    background: #fff;
+    width: 320px;
     height: 120px;
     position: fixed;
+    margin: 0 auto;
+    margin-top: calc(50vh - 120px);
+    left: 50%;
+    margin-left: -160px;
     border-radius: $vg-border-radius;
-    margin-left: 0;
-    margin-top: 0;
+
 
     .widget-header {
+        position: relative;
+
         span {
             float: left;
         }


### PR DESCRIPTION
Refactor callstatus polling. Make callstatus modal fullscreen. Blocksubsequent call requests. Fix irregular fontsizes. Closes #62.

### Description of fix
* Modal now takes 100& screen height/width. Clicking on the page beneath is now impossible. Removed clicking outside frame handler. Closing now only via close button. Refactored status poller. Notification messages are now properly progagated. Fontsize in search box is now clearner.
