### PR TITLE
Closes #66. Closes #67.

### DIFF
--- a/src/scss/base/mixins.scss
+++ b/src/scss/base/mixins.scss
@@ -1,5 +1,5 @@
 @mixin vg-gradient {
-    background: linear-gradient(to bottom, #fdfdfd 0%, #efefef 100%);
+    background: linear-gradient(to bottom, #fcfcfc 0%, #efefef 100%);
 }
 
 @mixin vg-modal-widget {

--- a/src/scss/components/popup.scss
+++ b/src/scss/components/popup.scss
@@ -5,7 +5,9 @@
 }
 
 input {
-    outline: none;
+    &:focus {
+        outline: 1px solid $vg-grey-light;
+    }
 
     &[type="text"],
     &[type="password"] {
@@ -16,9 +18,15 @@ input {
     }
 }
 
-// Keep select height consistent between Firefox and Chrome.
 select {
-    height: 30px;
+    outline: none;
+    height: 2rem;
+    background: $vg-grey-lightest;
+    border: 1px solid $vg-grey-lighter;
+
+    &:focus {
+        border: 1px solid $vg-grey-light;
+    }
 }
 
 // The login container.

--- a/src/scss/components/widget.scss
+++ b/src/scss/components/widget.scss
@@ -2,7 +2,7 @@
 
     // Resize fa icons.
     .fa {
-        font-size: 1.3rem;
+        font-size: 1.2rem;
 
         &.fa-vertical-align {
             vertical-align: middle;
@@ -39,6 +39,7 @@
 
         .status-indicators {
             width: $vg-widget-header-size;
+            text-align: left;
             padding-left: $vg-spacing-2;
             height: $vg-widget-header-size;
             position: relative;
@@ -55,7 +56,7 @@
             font-size: 1.5rem;
             right: $vg-spacing-gap;
             font-family: "FontAwesome";
-            opacity: 0.7;
+            opacity: 0.3;
             padding-top: 11px;
         }
     }


### PR DESCRIPTION
* Slightly decreased the widget icons size from 1.3rem to 1.2rem
* Slightly changed the background gradient to not look that white at the start
* Replaced the input type from search to text (that cross was a native ui thing)
* Positioned status-indicator a bit more to the left
* Made the chevrons use the same opacity level as the search icon (lighter)
* Added outline color on select and input
* Applied consistent styling on availability select